### PR TITLE
feat: added a simple example for a jsonnet app

### DIFF
--- a/jsonnet-app/deploy.jsonnet
+++ b/jsonnet-app/deploy.jsonnet
@@ -1,0 +1,37 @@
+[
+  {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: 'simple-deployment',
+    },
+    spec: {
+      replicas: 1,
+      selector: {
+        matchLabels: {
+          app: 'trivial-go-web-app',
+        },
+      },
+      template: {
+        metadata: {
+          labels: {
+            app: 'trivial-go-web-app',
+          },
+        },
+        spec: {
+          containers: [
+            {
+              name: 'webserver-simple',
+              image: 'docker.io/kostiscodefresh/gitops-simple-app:v1.0',
+              ports: [
+                {
+                  containerPort: 8080,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  },
+]

--- a/jsonnet-app/service.jsonnet
+++ b/jsonnet-app/service.jsonnet
@@ -1,0 +1,22 @@
+[
+  {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: 'simple-service',
+    },
+    spec: {
+      type: 'NodePort',
+      selector: {
+        app: 'trivial-go-web-app',
+      },
+      ports: [
+        {
+          nodePort: 31000,
+          protocol: 'TCP',
+          port: 8080,
+        },
+      ],
+    },
+  },
+]


### PR DESCRIPTION
It will be good to add an example of `jsonnet` too as it is officially [supported](https://argo-cd.readthedocs.io/en/stable/user-guide/jsonnet/) by ArgoCD

I have added a dead simple `jsonnet` app. If the maintainers want, in another PR I can add an example of slightly complex example with libraries (something which actually makes `jsonnet` powerful :)) 

Signed-off-by: Vikas Kumar <vikas@reachvikas.com>